### PR TITLE
Missing return get an error in Arduino IDE

### DIFF
--- a/src/F_BMI055_HMC5883L.hpp
+++ b/src/F_BMI055_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_BMI055_QMC5883L.hpp
+++ b/src/F_BMI055_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_BMI160_HMC5883L.hpp
+++ b/src/F_BMI160_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_BMI160_QMC5883L.hpp
+++ b/src/F_BMI160_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_ICM20689_HMC5883L.hpp
+++ b/src/F_ICM20689_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_ICM20689_QMC5883L.hpp
+++ b/src/F_ICM20689_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_ICM20690_HMC5883L.hpp
+++ b/src/F_ICM20690_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_ICM20690_QMC5883L.hpp
+++ b/src/F_ICM20690_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_IMU_Generic_HMC5883L.hpp
+++ b/src/F_IMU_Generic_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_IMU_Generic_QMC5883L.hpp
+++ b/src/F_IMU_Generic_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_LSM6DS3_HMC5883L.hpp
+++ b/src/F_LSM6DS3_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_LSM6DS3_QMC5883L.hpp
+++ b/src/F_LSM6DS3_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_LSM6DSL_HMC5883L.hpp
+++ b/src/F_LSM6DSL_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_LSM6DSL_QMC5883L.hpp
+++ b/src/F_LSM6DSL_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_MPU6050_HMC5883L.hpp
+++ b/src/F_MPU6050_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_MPU6050_QMC5883L.hpp
+++ b/src/F_MPU6050_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_MPU6500_HMC5883L.hpp
+++ b/src/F_MPU6500_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_MPU6500_QMC5883L.hpp
+++ b/src/F_MPU6500_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_MPU6515_HMC5883L.hpp
+++ b/src/F_MPU6515_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_MPU6515_QMC5883L.hpp
+++ b/src/F_MPU6515_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_QMI8658_HMC5883L.hpp
+++ b/src/F_QMI8658_HMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x1E);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {

--- a/src/F_QMI8658_QMC5883L.hpp
+++ b/src/F_QMI8658_QMC5883L.hpp
@@ -16,6 +16,7 @@ public:
 		if (e) { return e; }
 		e = MAG.init(cal, 0x0D);
 		if (e) { return -2; }
+		return 0;
 	}
 
 	void update() override {


### PR DESCRIPTION
I've been conducting a test with MPU6050 and QMC5883L, and the Arduino IDE was returning an error even though everything was set up correctly. So I ended up discovering that a return was missing at the end of the init function in case the sensors were configured correctly. I noticed that other functions had the same issue, so I made the change as well.