### PR TITLE
Issue #26: Remove use of delay() by using status check.

### DIFF
--- a/src/F_LSM6DSL.cpp
+++ b/src/F_LSM6DSL.cpp
@@ -16,14 +16,15 @@ int LSM6DSL::init(calData cal, uint8_t address)
 		calibration = cal;
 	}
 	
-	uint8_t IMUWhoAmI = readByte(IMUAddress, LSM6DSL_WHO_AM_I);
+	// Wait up to 100ms for IMU to become ready.
+	uint8_t IMUWhoAmI = checkReady(IMUAddress, 500);
 	if (!(IMUWhoAmI == LSM6DSL_WHOAMI_DEFAULT_VALUE_A) && !(IMUWhoAmI == LSM6DSL_WHOAMI_DEFAULT_VALUE_B)) {
 		return -1;
 	}
 
 	// reset device
 	writeByte(IMUAddress, LSM6DSL_CTRL3_C, 0x01);   // Toggle softreset
-	delay(100);										// wait for reset
+	while (!checkReady(IMUAddress, 100));			// wait for reset
 	
 	writeByte(IMUAddress, LSM6DSL_CTRL1_XL, 0x47);	// Start up accelerometer, set range to +-16g, set output data rate to 104hz, BW_XL bits to 11.
 	writeByte(IMUAddress, LSM6DSL_CTRL2_G, 0x4C);	// Start up gyroscope, set range to -+2000dps, output data rate to 104hz.

--- a/src/F_LSM6DSL.hpp
+++ b/src/F_LSM6DSL.hpp
@@ -136,5 +136,17 @@ private:
 			dest[i++] = Wire.read();
 		}         // Put read results in the Rx buffer
 	}
+
+	uint8_t checkReady(uint8_t address, uint8_t timeout)
+	{
+		uint8_t IMUWhoAmI = 0;
+		// Wait until a valid byte is returned, up until timeout value.
+		for (uint8_t checkCount = timeout; checkCount > 0; checkCount--) {
+			IMUWhoAmI = readByte(address, LSM6DSL_WHO_AM_I);
+			if (IMUWhoAmI == 0xFF) { delay(1); } else { break; }
+		}
+		// Return IMU identifier if found.
+		return IMUWhoAmI;
+	}
 };
 #endif /* _F_LSM6DSL_H_ */


### PR DESCRIPTION
Fixes #26.

This only applies to the `LSM6DSL` driver but could potentially be extended to every driver where there is a `delay()` call.