### PR TITLE
Support non-default I2C masters

### DIFF
--- a/src/F_AK09918.hpp
+++ b/src/F_AK09918.hpp
@@ -58,7 +58,7 @@ enum AK09918_err_type_t {
 
 class AK09918 : public IMUBase {
 public:
-	explicit AK09918(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit AK09918(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -109,6 +109,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_AK09918.hpp
+++ b/src/F_AK09918.hpp
@@ -58,7 +58,7 @@ enum AK09918_err_type_t {
 
 class AK09918 : public IMUBase {
 public:
-	AK09918() {};
+	explicit AK09918(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -112,32 +112,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_AK8963.hpp
+++ b/src/F_AK8963.hpp
@@ -33,7 +33,7 @@
 
 class AK8963 : public IMUBase {
 public:
-	AK8963() {};
+	explicit AK8963(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -84,32 +84,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_AK8963.hpp
+++ b/src/F_AK8963.hpp
@@ -33,7 +33,7 @@
 
 class AK8963 : public IMUBase {
 public:
-	explicit AK8963(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit AK8963(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -81,6 +81,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_AK8975.hpp
+++ b/src/F_AK8975.hpp
@@ -33,7 +33,7 @@
 
 class AK8975 : public IMUBase {
 public:
-	explicit AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit AK8975(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -81,6 +81,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_AK8975.hpp
+++ b/src/F_AK8975.hpp
@@ -33,7 +33,7 @@
 
 class AK8975 : public IMUBase {
 public:
-	AK8975() {};
+	explicit AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -84,32 +84,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_BMI055.hpp
+++ b/src/F_BMI055.hpp
@@ -41,7 +41,7 @@
 
 class BMI055 : public IMUBase {
 public:
-	explicit BMI055(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit BMI055(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -94,6 +94,7 @@ private:
 	uint8_t AccelAddress;
 	uint8_t GyroAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_BMI055.hpp
+++ b/src/F_BMI055.hpp
@@ -41,7 +41,7 @@
 
 class BMI055 : public IMUBase {
 public:
-	BMI055() {};
+	explicit BMI055(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -97,32 +97,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 };

--- a/src/F_BMI055_AK8975.hpp
+++ b/src/F_BMI055_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class BMI055_QMC5883L : public IMUBase {
 public:
-	BMI055_QMC5883L() {};
+	explicit BMI055_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI055_AK8975.hpp
+++ b/src/F_BMI055_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class BMI055_QMC5883L : public IMUBase {
 public:
-	explicit BMI055_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit BMI055_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI055_HMC5883L.hpp
+++ b/src/F_BMI055_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class BMI055_HMC5883L : public IMUBase {
 public:
-	BMI055_HMC5883L() {};
+	explicit BMI055_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI055_HMC5883L.hpp
+++ b/src/F_BMI055_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class BMI055_HMC5883L : public IMUBase {
 public:
-	explicit BMI055_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit BMI055_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI055_QMC5883L.hpp
+++ b/src/F_BMI055_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class BMI055_QMC5883L : public IMUBase {
 public:
-	BMI055_QMC5883L() {};
+	explicit BMI055_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI055_QMC5883L.hpp
+++ b/src/F_BMI055_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class BMI055_QMC5883L : public IMUBase {
 public:
-	explicit BMI055_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit BMI055_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI160.hpp
+++ b/src/F_BMI160.hpp
@@ -103,7 +103,7 @@
 
 class BMI160 : public IMUBase {
 public:
-	explicit BMI160(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit BMI160(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -154,6 +154,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_BMI160.hpp
+++ b/src/F_BMI160.hpp
@@ -103,7 +103,7 @@
 
 class BMI160 : public IMUBase {
 public:
-	BMI160() {};
+	explicit BMI160(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -157,32 +157,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 };

--- a/src/F_BMI160_AK8975.hpp
+++ b/src/F_BMI160_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class BMI160_AK8975 : public IMUBase {
 public:
-	BMI160_AK8975() {};
+	explicit BMI160_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI160_AK8975.hpp
+++ b/src/F_BMI160_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class BMI160_AK8975 : public IMUBase {
 public:
-	explicit BMI160_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit BMI160_AK8975(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI160_HMC5883L.hpp
+++ b/src/F_BMI160_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class BMI160_HMC5883L : public IMUBase {
 public:
-	BMI160_HMC5883L() {};
+	explicit BMI160_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI160_HMC5883L.hpp
+++ b/src/F_BMI160_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class BMI160_HMC5883L : public IMUBase {
 public:
-	explicit BMI160_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit BMI160_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI160_QMC5883L.hpp
+++ b/src/F_BMI160_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class BMI160_QMC5883L : public IMUBase {
 public:
-	BMI160_QMC5883L() {};
+	explicit BMI160_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMI160_QMC5883L.hpp
+++ b/src/F_BMI160_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class BMI160_QMC5883L : public IMUBase {
 public:
-	explicit BMI160_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit BMI160_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_BMX055.hpp
+++ b/src/F_BMX055.hpp
@@ -61,7 +61,7 @@
 
 class BMX055 : public IMUBase {
 public:
-	BMX055() {};
+	explicit BMX055(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -121,32 +121,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 };

--- a/src/F_BMX055.hpp
+++ b/src/F_BMX055.hpp
@@ -61,7 +61,7 @@
 
 class BMX055 : public IMUBase {
 public:
-	explicit BMX055(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit BMX055(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -118,6 +118,7 @@ private:
 	uint8_t GyroAddress;
 	uint8_t MagAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_HMC5883L.hpp
+++ b/src/F_HMC5883L.hpp
@@ -28,7 +28,7 @@
 
 class HMC5883L : public IMUBase {
 public:
-	HMC5883L() {};
+	explicit HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -76,32 +76,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 };

--- a/src/F_HMC5883L.hpp
+++ b/src/F_HMC5883L.hpp
@@ -28,7 +28,7 @@
 
 class HMC5883L : public IMUBase {
 public:
-	explicit HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit HMC5883L(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -73,6 +73,8 @@ private:
 
 	calData calibration;
 	uint8_t IMUAddress;
+
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_ICM20689.hpp
+++ b/src/F_ICM20689.hpp
@@ -84,7 +84,7 @@
 
 class ICM20689 : public IMUBase {
 public:
-	explicit ICM20689(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit ICM20689(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -135,6 +135,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_ICM20689.hpp
+++ b/src/F_ICM20689.hpp
@@ -84,7 +84,7 @@
 
 class ICM20689 : public IMUBase {
 public:
-	ICM20689() {};
+	explicit ICM20689(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -138,32 +138,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_ICM20689_AK8975.hpp
+++ b/src/F_ICM20689_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class ICM20689_AK8975 : public IMUBase {
 public:
-	explicit ICM20689_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit ICM20689_AK8975(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20689_AK8975.hpp
+++ b/src/F_ICM20689_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class ICM20689_AK8975 : public IMUBase {
 public:
-	ICM20689_AK8975() {};
+	explicit ICM20689_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20689_HMC5883L.hpp
+++ b/src/F_ICM20689_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class ICM20689_HMC5883L : public IMUBase {
 public:
-	ICM20689_HMC5883L() {};
+	explicit ICM20689_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20689_HMC5883L.hpp
+++ b/src/F_ICM20689_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class ICM20689_HMC5883L : public IMUBase {
 public:
-	explicit ICM20689_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit ICM20689_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20689_QMC5883L.hpp
+++ b/src/F_ICM20689_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class ICM20689_QMC5883L : public IMUBase {
 public:
-	explicit ICM20689_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit ICM20689_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20689_QMC5883L.hpp
+++ b/src/F_ICM20689_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class ICM20689_QMC5883L : public IMUBase {
 public:
-	ICM20689_QMC5883L() {};
+	explicit ICM20689_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20690.hpp
+++ b/src/F_ICM20690.hpp
@@ -84,7 +84,7 @@
 
 class ICM20690 : public IMUBase {
 public:
-	explicit ICM20690(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit ICM20690(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -134,6 +134,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_ICM20690.hpp
+++ b/src/F_ICM20690.hpp
@@ -84,7 +84,7 @@
 
 class ICM20690 : public IMUBase {
 public:
-	ICM20690() {};
+	explicit ICM20690(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -137,32 +137,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_ICM20690_AK8975.hpp
+++ b/src/F_ICM20690_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class ICM20690_AK8975 : public IMUBase {
 public:
-	ICM20690_AK8975() {};
+	explicit ICM20690_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20690_AK8975.hpp
+++ b/src/F_ICM20690_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class ICM20690_AK8975 : public IMUBase {
 public:
-	explicit ICM20690_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit ICM20690_AK8975(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20690_HMC5883L.hpp
+++ b/src/F_ICM20690_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class ICM20690_HMC5883L : public IMUBase {
 public:
-	ICM20690_HMC5883L() {};
+	explicit ICM20690_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20690_HMC5883L.hpp
+++ b/src/F_ICM20690_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class ICM20690_HMC5883L : public IMUBase {
 public:
-	explicit ICM20690_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit ICM20690_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20690_QMC5883L.hpp
+++ b/src/F_ICM20690_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class ICM20690_QMC5883L : public IMUBase {
 public:
-	ICM20690_QMC5883L() {};
+	explicit ICM20690_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_ICM20690_QMC5883L.hpp
+++ b/src/F_ICM20690_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class ICM20690_QMC5883L : public IMUBase {
 public:
-	explicit ICM20690_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit ICM20690_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_IMU_Generic.hpp
+++ b/src/F_IMU_Generic.hpp
@@ -161,7 +161,7 @@
 
 class IMU_Generic : public IMUBase {
 public:
-	IMU_Generic() {};
+	explicit IMU_Generic(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -217,32 +217,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_IMU_Generic.hpp
+++ b/src/F_IMU_Generic.hpp
@@ -161,7 +161,7 @@
 
 class IMU_Generic : public IMUBase {
 public:
-	explicit IMU_Generic(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit IMU_Generic(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -214,6 +214,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_IMU_Generic_AK8975.hpp
+++ b/src/F_IMU_Generic_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class IMU_Generic_AK8975 : public IMUBase {
 public:
-	explicit IMU_Generic_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit IMU_Generic_AK8975(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_IMU_Generic_AK8975.hpp
+++ b/src/F_IMU_Generic_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class IMU_Generic_AK8975 : public IMUBase {
 public:
-	IMU_Generic_AK8975() {};
+	explicit IMU_Generic_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_IMU_Generic_HMC5883L.hpp
+++ b/src/F_IMU_Generic_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class IMU_Generic_HMC5883L : public IMUBase {
 public:
-	explicit IMU_Generic_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit IMU_Generic_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_IMU_Generic_HMC5883L.hpp
+++ b/src/F_IMU_Generic_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class IMU_Generic_HMC5883L : public IMUBase {
 public:
-	IMU_Generic_HMC5883L() {};
+	explicit IMU_Generic_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_IMU_Generic_QMC5883L.hpp
+++ b/src/F_IMU_Generic_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class IMU_Generic_QMC5883L : public IMUBase {
 public:
-	explicit IMU_Generic_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit IMU_Generic_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_IMU_Generic_QMC5883L.hpp
+++ b/src/F_IMU_Generic_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class IMU_Generic_QMC5883L : public IMUBase {
 public:
-	IMU_Generic_QMC5883L() {};
+	explicit IMU_Generic_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DS3.hpp
+++ b/src/F_LSM6DS3.hpp
@@ -54,7 +54,7 @@
 
 class LSM6DS3 : public IMUBase {
 public:
-	explicit LSM6DS3(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit LSM6DS3(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -104,6 +104,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_LSM6DS3.hpp
+++ b/src/F_LSM6DS3.hpp
@@ -54,7 +54,7 @@
 
 class LSM6DS3 : public IMUBase {
 public:
-	LSM6DS3() {};
+	explicit LSM6DS3(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -107,32 +107,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 };

--- a/src/F_LSM6DS3_AK8975.hpp
+++ b/src/F_LSM6DS3_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DS3_AK8975 : public IMUBase {
 public:
-	LSM6DS3_AK8975() {};
+	explicit LSM6DS3_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DS3_AK8975.hpp
+++ b/src/F_LSM6DS3_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DS3_AK8975 : public IMUBase {
 public:
-	explicit LSM6DS3_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit LSM6DS3_AK8975(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DS3_HMC5883L.hpp
+++ b/src/F_LSM6DS3_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DS3_HMC5883L : public IMUBase {
 public:
-	LSM6DS3_HMC5883L() {};
+	explicit LSM6DS3_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DS3_HMC5883L.hpp
+++ b/src/F_LSM6DS3_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DS3_HMC5883L : public IMUBase {
 public:
-	explicit LSM6DS3_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit LSM6DS3_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DS3_QMC5883L.hpp
+++ b/src/F_LSM6DS3_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DS3_QMC5883L : public IMUBase {
 public:
-	LSM6DS3_QMC5883L() {};
+	explicit LSM6DS3_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DS3_QMC5883L.hpp
+++ b/src/F_LSM6DS3_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DS3_QMC5883L : public IMUBase {
 public:
-	explicit LSM6DS3_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit LSM6DS3_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DSL.hpp
+++ b/src/F_LSM6DSL.hpp
@@ -55,7 +55,7 @@
 
 class LSM6DSL : public IMUBase {
 public:
-	explicit LSM6DSL(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit LSM6DSL(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -105,6 +105,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_LSM6DSL.hpp
+++ b/src/F_LSM6DSL.hpp
@@ -55,7 +55,7 @@
 
 class LSM6DSL : public IMUBase {
 public:
-	LSM6DSL() {};
+	explicit LSM6DSL(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -108,32 +108,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 };

--- a/src/F_LSM6DSL_AK8975.hpp
+++ b/src/F_LSM6DSL_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DSL_AK8975 : public IMUBase {
 public:
-	LSM6DSL_AK8975() {};
+	explicit LSM6DSL_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DSL_AK8975.hpp
+++ b/src/F_LSM6DSL_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DSL_AK8975 : public IMUBase {
 public:
-	explicit LSM6DSL_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit LSM6DSL_AK8975(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DSL_HMC5883L.hpp
+++ b/src/F_LSM6DSL_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DSL_HMC5883L : public IMUBase {
 public:
-	explicit LSM6DSL_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit LSM6DSL_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DSL_HMC5883L.hpp
+++ b/src/F_LSM6DSL_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DSL_HMC5883L : public IMUBase {
 public:
-	LSM6DSL_HMC5883L() {};
+	explicit LSM6DSL_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DSL_QMC5883L.hpp
+++ b/src/F_LSM6DSL_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DSL_QMC5883L : public IMUBase {
 public:
-	explicit LSM6DSL_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit LSM6DSL_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_LSM6DSL_QMC5883L.hpp
+++ b/src/F_LSM6DSL_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class LSM6DSL_QMC5883L : public IMUBase {
 public:
-	LSM6DSL_QMC5883L() {};
+	explicit LSM6DSL_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6050.hpp
+++ b/src/F_MPU6050.hpp
@@ -70,7 +70,7 @@
 
 class MPU6050 : public IMUBase {
 public:
-	explicit MPU6050(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6050(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -120,6 +120,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_MPU6050.hpp
+++ b/src/F_MPU6050.hpp
@@ -70,7 +70,7 @@
 
 class MPU6050 : public IMUBase {
 public:
-	MPU6050() {};
+	explicit MPU6050(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -123,32 +123,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_MPU6050_AK8975.hpp
+++ b/src/F_MPU6050_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class MPU6050_AK8975 : public IMUBase {
 public:
-	MPU6050_AK8975() {};
+	explicit MPU6050_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6050_AK8975.hpp
+++ b/src/F_MPU6050_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class MPU6050_AK8975 : public IMUBase {
 public:
-	explicit MPU6050_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6050_AK8975(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6050_HMC5883L.hpp
+++ b/src/F_MPU6050_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6050_HMC5883L : public IMUBase {
 public:
-	MPU6050_HMC5883L() {};
+	explicit MPU6050_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6050_HMC5883L.hpp
+++ b/src/F_MPU6050_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6050_HMC5883L : public IMUBase {
 public:
-	explicit MPU6050_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6050_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6050_QMC5883L.hpp
+++ b/src/F_MPU6050_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6050_QMC5883L : public IMUBase {
 public:
-	explicit MPU6050_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6050_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6050_QMC5883L.hpp
+++ b/src/F_MPU6050_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6050_QMC5883L : public IMUBase {
 public:
-	MPU6050_QMC5883L() {};
+	explicit MPU6050_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6500.hpp
+++ b/src/F_MPU6500.hpp
@@ -140,7 +140,7 @@
 
 class MPU6500 : public IMUBase {
 public:
-	MPU6500() {};
+	explicit MPU6500(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -193,32 +193,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_MPU6500.hpp
+++ b/src/F_MPU6500.hpp
@@ -140,7 +140,7 @@
 
 class MPU6500 : public IMUBase {
 public:
-	explicit MPU6500(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6500(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -190,6 +190,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_MPU6500_AK8975.hpp
+++ b/src/F_MPU6500_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class MPU6500_AK8975 : public IMUBase {
 public:
-	explicit MPU6500_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6500_AK8975(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6500_AK8975.hpp
+++ b/src/F_MPU6500_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class MPU6500_AK8975 : public IMUBase {
 public:
-	MPU6500_AK8975() {};
+	explicit MPU6500_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6500_HMC5883L.hpp
+++ b/src/F_MPU6500_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6500_HMC5883L : public IMUBase {
 public:
-	MPU6500_HMC5883L() {};
+	explicit MPU6500_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6500_HMC5883L.hpp
+++ b/src/F_MPU6500_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6500_HMC5883L : public IMUBase {
 public:
-	explicit MPU6500_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6500_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6500_QMC5883L.hpp
+++ b/src/F_MPU6500_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6500_QMC5883L : public IMUBase {
 public:
-	explicit MPU6500_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6500_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6500_QMC5883L.hpp
+++ b/src/F_MPU6500_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6500_QMC5883L : public IMUBase {
 public:
-	MPU6500_QMC5883L() {};
+	explicit MPU6500_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6515.hpp
+++ b/src/F_MPU6515.hpp
@@ -140,7 +140,7 @@
 
 class MPU6515 : public IMUBase {
 public:
-	MPU6515() {};
+	explicit MPU6515(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -193,32 +193,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_MPU6515.hpp
+++ b/src/F_MPU6515.hpp
@@ -140,7 +140,7 @@
 
 class MPU6515 : public IMUBase {
 public:
-	explicit MPU6515(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6515(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -190,6 +190,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_MPU6515_AK8975.hpp
+++ b/src/F_MPU6515_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class MPU6515_AK8975 : public IMUBase {
 public:
-	MPU6515_AK8975() {};
+	explicit MPU6515_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6515_AK8975.hpp
+++ b/src/F_MPU6515_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class MPU6515_AK8975 : public IMUBase {
 public:
-	explicit MPU6515_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6515_AK8975(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6515_HMC5883L.hpp
+++ b/src/F_MPU6515_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6515_HMC5883L : public IMUBase {
 public:
-	MPU6515_HMC5883L() {};
+	explicit MPU6515_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6515_HMC5883L.hpp
+++ b/src/F_MPU6515_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6515_HMC5883L : public IMUBase {
 public:
-	explicit MPU6515_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6515_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6515_QMC5883L.hpp
+++ b/src/F_MPU6515_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6515_QMC5883L : public IMUBase {
 public:
-	MPU6515_QMC5883L() {};
+	explicit MPU6515_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6515_QMC5883L.hpp
+++ b/src/F_MPU6515_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class MPU6515_QMC5883L : public IMUBase {
 public:
-	explicit MPU6515_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6515_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_MPU6886.hpp
+++ b/src/F_MPU6886.hpp
@@ -140,7 +140,7 @@
 
 class MPU6886 : public IMUBase {
 public:
-	MPU6886() {};
+	explicit MPU6886(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -193,32 +193,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_MPU6886.hpp
+++ b/src/F_MPU6886.hpp
@@ -140,7 +140,7 @@
 
 class MPU6886 : public IMUBase {
 public:
-	explicit MPU6886(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU6886(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -190,6 +190,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_MPU9250.hpp
+++ b/src/F_MPU9250.hpp
@@ -142,7 +142,7 @@
 
 class MPU9250 : public IMUBase {
 public:
-	explicit MPU9250(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU9250(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -199,6 +199,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_MPU9250.hpp
+++ b/src/F_MPU9250.hpp
@@ -142,7 +142,7 @@
 
 class MPU9250 : public IMUBase {
 public:
-	MPU9250() {};
+	explicit MPU9250(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -202,32 +202,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_MPU9255.hpp
+++ b/src/F_MPU9255.hpp
@@ -142,7 +142,7 @@
 
 class MPU9255 : public IMUBase {
 public:
-	MPU9255() {};
+	explicit MPU9255(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -202,32 +202,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 

--- a/src/F_MPU9255.hpp
+++ b/src/F_MPU9255.hpp
@@ -142,7 +142,7 @@
 
 class MPU9255 : public IMUBase {
 public:
-	explicit MPU9255(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit MPU9255(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -199,6 +199,7 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_QMC5883L.hpp
+++ b/src/F_QMC5883L.hpp
@@ -28,7 +28,7 @@
 
 class QMC5883L : public IMUBase {
 public:
-	explicit QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit QMC5883L(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -78,6 +78,8 @@ private:
 
 	calData calibration;
 	uint8_t IMUAddress;
+
+	TwoWire& wire;
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{

--- a/src/F_QMC5883L.hpp
+++ b/src/F_QMC5883L.hpp
@@ -28,7 +28,7 @@
 
 class QMC5883L : public IMUBase {
 public:
-	QMC5883L() {};
+	explicit QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -81,32 +81,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 };

--- a/src/F_QMI8658.hpp
+++ b/src/F_QMI8658.hpp
@@ -59,7 +59,7 @@
 
 class QMI8658 : public IMUBase {
 public:
-	QMI8658() {};
+	explicit QMI8658(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -114,32 +114,32 @@ private:
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 	{
-		Wire.beginTransmission(address);  // Initialize the Tx buffer
-		Wire.write(subAddress);           // Put slave register address in Tx buffer
-		Wire.write(data);                 // Put data in Tx buffer
-		Wire.endTransmission();           // Send the Tx buffer
+		wire.beginTransmission(address);  // Initialize the Tx buffer
+		wire.write(subAddress);           // Put slave register address in Tx buffer
+		wire.write(data);                 // Put data in Tx buffer
+		wire.endTransmission();           // Send the Tx buffer
 	}
 
 	uint8_t readByte(uint8_t address, uint8_t subAddress)
 	{
 		uint8_t data; 						   // `data` will store the register data
-		Wire.beginTransmission(address);         // Initialize the Tx buffer
-		Wire.write(subAddress);                  // Put slave register address in Tx buffer
-		Wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
-		Wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
-		data = Wire.read();                      // Fill Rx buffer with result
+		wire.beginTransmission(address);         // Initialize the Tx buffer
+		wire.write(subAddress);                  // Put slave register address in Tx buffer
+		wire.endTransmission(false);             // Send the Tx buffer, but send a restart to keep connection alive
+		wire.requestFrom(address, (uint8_t)1);  // Read one byte from slave register address
+		data = wire.read();                      // Fill Rx buffer with result
 		return data;                             // Return data read from slave register
 	}
 
 	void readBytes(uint8_t address, uint8_t subAddress, uint8_t count, uint8_t* dest)
 	{
-		Wire.beginTransmission(address);   // Initialize the Tx buffer
-		Wire.write(subAddress);            // Put slave register address in Tx buffer
-		Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+		wire.beginTransmission(address);   // Initialize the Tx buffer
+		wire.write(subAddress);            // Put slave register address in Tx buffer
+		wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
 		uint8_t i = 0;
-		Wire.requestFrom(address, count);  // Read bytes from slave register address
-		while (Wire.available()) {
-			dest[i++] = Wire.read();
+		wire.requestFrom(address, count);  // Read bytes from slave register address
+		while (wire.available()) {
+			dest[i++] = wire.read();
 		}         // Put read results in the Rx buffer
 	}
 };

--- a/src/F_QMI8658.hpp
+++ b/src/F_QMI8658.hpp
@@ -59,7 +59,7 @@
 
 class QMI8658 : public IMUBase {
 public:
-	explicit QMI8658(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit QMI8658(TwoWire& wire = Wire) : wire(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override;
@@ -110,6 +110,8 @@ private:
 	calData calibration;
 	uint8_t IMUAddress;
 
+	TwoWire& wire;
+	
 	bool dataAvailable(){ return (readByte(IMUAddress, QMI8658_STATUS0) & 0x03);}
 
 	void writeByte(uint8_t address, uint8_t subAddress, uint8_t data)

--- a/src/F_QMI8658_AK09918.hpp
+++ b/src/F_QMI8658_AK09918.hpp
@@ -8,7 +8,7 @@
 
 class QMI8658_AK09918 : public IMUBase {
 public:
-	QMI8658_AK09918() {};
+	explicit QMI8658_AK09918(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_QMI8658_AK09918.hpp
+++ b/src/F_QMI8658_AK09918.hpp
@@ -8,7 +8,7 @@
 
 class QMI8658_AK09918 : public IMUBase {
 public:
-	explicit QMI8658_AK09918(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit QMI8658_AK09918(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_QMI8658_AK8975.hpp
+++ b/src/F_QMI8658_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class QMI8658_AK8975 : public IMUBase {
 public:
-	explicit QMI8658_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit QMI8658_AK8975(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_QMI8658_AK8975.hpp
+++ b/src/F_QMI8658_AK8975.hpp
@@ -8,7 +8,7 @@
 
 class QMI8658_AK8975 : public IMUBase {
 public:
-	QMI8658_AK8975() {};
+	explicit QMI8658_AK8975(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_QMI8658_HMC5883L.hpp
+++ b/src/F_QMI8658_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class QMI8658_HMC5883L : public IMUBase {
 public:
-	QMI8658_HMC5883L() {};
+	explicit QMI8658_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_QMI8658_HMC5883L.hpp
+++ b/src/F_QMI8658_HMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class QMI8658_HMC5883L : public IMUBase {
 public:
-	explicit QMI8658_HMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit QMI8658_HMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_QMI8658_QMC5883L.hpp
+++ b/src/F_QMI8658_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class QMI8658_QMC5883L : public IMUBase {
 public:
-	explicit QMI8658_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
+	explicit QMI8658_QMC5883L(TwoWire& wire = Wire) : IMU(wire), MAG(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/F_QMI8658_QMC5883L.hpp
+++ b/src/F_QMI8658_QMC5883L.hpp
@@ -8,7 +8,7 @@
 
 class QMI8658_QMC5883L : public IMUBase {
 public:
-	QMI8658_QMC5883L() {};
+	explicit QMI8658_QMC5883L(TwoWire& wire = Wire) : IMUBase(wire) {};
 
 	// Inherited via IMUBase
 	int init(calData cal, uint8_t address) override {

--- a/src/IMUBase.hpp
+++ b/src/IMUBase.hpp
@@ -76,10 +76,6 @@ public:
 	virtual String IMUManufacturer(){
 		return "Unknown";
 	}
-
-protected:
-	IMUBase(TwoWire& wire) : wire(wire) {}
-	TwoWire& wire;
 };
 
 #endif /* _F_IMUBase_H_ */

--- a/src/IMUBase.hpp
+++ b/src/IMUBase.hpp
@@ -76,6 +76,10 @@ public:
 	virtual String IMUManufacturer(){
 		return "Unknown";
 	}
+
+protected:
+	IMUBase(TwoWire& wire) : wire(wire) {}
+	TwoWire& wire;
 };
 
 #endif /* _F_IMUBase_H_ */


### PR DESCRIPTION
This PR adds support for non-default I2C masters #30. A TwoWire instance can now be optionally parsed into the contructor, e.g.

```
MPU6050 imu(Wire2)
```

Given all currently supported IMUs are I2C devices, I've put the TwoWire reference in I2CBase.