### PR TITLE
Issue #10: Add support for LSM6DSO.

### DIFF
--- a/src/F_LSM6DS3.cpp
+++ b/src/F_LSM6DS3.cpp
@@ -7,7 +7,7 @@ int LSM6DS3::init(calData cal, uint8_t address)
 	//initialize address variable and calibration data.
 	IMUAddress = address;
 
-	if (cal.valid == false) 
+	if (cal.valid == false)
 	{
 		calibration = { 0 };
 	}
@@ -15,18 +15,19 @@ int LSM6DS3::init(calData cal, uint8_t address)
 	{
 		calibration = cal;
 	}
-	
-	uint8_t IMUWhoAmI = checkReady(IMUAddress, 500);
-	if (!(IMUWhoAmI == LSM6DS3_WHOAMI_DEFAULT_VALUE)) {
-		if (!(IMUWhoAmI == LSM6DS3TR_C_WHOAMI_DEFAULT_VALUE)) {
-			return -1;
-		}
+
+	uint8_t IMUWhoAmI = checkReady(IMUAddress, 100);
+	if (IMUWhoAmI != LSM6DS3_WHOAMI_DEFAULT_VALUE &&
+		IMUWhoAmI != LSM6DS3TR_C_WHOAMI_DEFAULT_VALUE &&
+		IMUWhoAmI != LSM6DSO_WHOAMI_DEFAULT_VALUE)
+	{
+		return -1;
 	}
 
 	// reset device
 	writeByteI2C(wire, IMUAddress, LSM6DS3_CTRL3_C, 0x01);   // Toggle softreset
 	while (!checkReady(IMUAddress, 100));			// wait for reset
-	
+
 	writeByteI2C(wire, IMUAddress, LSM6DS3_CTRL1_XL, 0x47);	// Start up accelerometer, set range to +-16g, set output data rate to 104hz, BW_XL bits to 11.
 	writeByteI2C(wire, IMUAddress, LSM6DS3_CTRL2_G, 0x4C);	// Start up gyroscope, set range to -+2000dps, output data rate to 104hz.
 	writeByteI2C(wire, IMUAddress, LSM6DS3_CTRL4_C, 0x80);	// Set XL_BW_SCAL_ODR;

--- a/src/F_LSM6DS3.hpp
+++ b/src/F_LSM6DS3.hpp
@@ -53,6 +53,7 @@
 
 #define LSM6DS3_WHOAMI_DEFAULT_VALUE	0x69
 #define LSM6DS3TR_C_WHOAMI_DEFAULT_VALUE 0x6A
+#define LSM6DSO_WHOAMI_DEFAULT_VALUE 0x6C
 
 #define LSM6DS3_DEFAULT_ADDRESS 0x6B
 
@@ -109,7 +110,7 @@ private:
 	uint8_t IMUAddress;
 
 	TwoWire& wire;
-	
+
 	uint8_t checkReady(uint8_t address, uint8_t timeout)
 	{
 		uint8_t IMUWhoAmI = 0;


### PR DESCRIPTION
Fixes https://github.com/LiquidCGS/FastIMU/issues/10.

I'm not sure this is solved in the best way -- just piggy-backing off LSM6DS3 -- but it seems to work pretty well.